### PR TITLE
兼容低版本.net 3.5

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -24,7 +24,24 @@ namespace WeChatGetKey
 			}
 			Console.WriteLine("[+] Done");
 		}
-		private static void ReadTest()
+        private static bool IsNullOrWhiteSpace(string value)
+        {
+            if (value == null)
+            {
+                return true;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (!char.IsWhiteSpace(value[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        private static void ReadTest()
 		{
 			List<int> SupportList = null;
 			Process WeChatProcess = null;
@@ -56,7 +73,7 @@ namespace WeChatGetKey
 				{
 					int WeChatKey = (int)Program.WeChatWinBaseAddress + SupportList[4];
 					string HexKey = Program.GetHex(WeChatProcess.Handle, (IntPtr)WeChatKey);
-					if (string.IsNullOrWhiteSpace(HexKey))
+					if (IsNullOrWhiteSpace(HexKey))
 					{
 						Console.WriteLine("[-] WeChat Is Run, But Maybe No Login");
 						return;
@@ -67,7 +84,7 @@ namespace WeChatGetKey
 						Console.WriteLine("[+] WeChatName: " + Program.GetName(WeChatProcess.Handle, (IntPtr)WeChatName, 100));
 						int WeChatAccount = (int)Program.WeChatWinBaseAddress + SupportList[1];
 						string Account = Program.GetMobile(WeChatProcess.Handle, (IntPtr)WeChatAccount);
-						if (string.IsNullOrWhiteSpace(Account))
+						if (IsNullOrWhiteSpace(Account))
 						{
 							Console.WriteLine("[-] WeChatAccount: Maybe User Is No Set Account");
 						}
@@ -77,7 +94,7 @@ namespace WeChatGetKey
 						}
 						int WeChatMobile = (int)Program.WeChatWinBaseAddress + SupportList[2];
 						string Mobile = Program.GetMobile(WeChatProcess.Handle, (IntPtr)WeChatMobile);
-						if (string.IsNullOrWhiteSpace(Mobile))
+						if (IsNullOrWhiteSpace(Mobile))
 						{
 							Console.WriteLine("[-] WeChatMobile: Maybe User Is No Binding Mobile");
 						}
@@ -87,7 +104,7 @@ namespace WeChatGetKey
 						}
 						int WeChatMail = (int)Program.WeChatWinBaseAddress + SupportList[3];
 						string Mail = Program.GetMail(WeChatProcess.Handle, (IntPtr)WeChatMail);
-						if (string.IsNullOrWhiteSpace(Mail) != false) { }
+						if (IsNullOrWhiteSpace(Mail) != false) { }
 						else
 						{
 							Console.WriteLine("[+] WeChatMail: " + Program.GetMail(WeChatProcess.Handle, (IntPtr)WeChatMail, 100));


### PR DESCRIPTION
在Windows 7等旧版本系统上默认不能存在高版本的.net 4，不过有稍微低版本的.net 3.5，低版本的.net的string没有IsNullOrWhiteSpace方法，我反编译了IsNullOrWhiteSpace方法把它加到代码里了，这样方便编译生成兼容性的SharpWxDump。
修改前.net 3.5编译不通过：
<img width="986" alt="Snipaste_2022-12-08_11-04-36" src="https://user-images.githubusercontent.com/24275308/206347578-5f2dd6ed-977a-4d11-bba0-2238652c4277.png">
Windows 7系统默认有.net 3.5：
![image](https://user-images.githubusercontent.com/24275308/206347733-0b9822df-1e01-4428-904b-004fd74448a9.png)
修改后.net 3.5编译通过：
![image](https://user-images.githubusercontent.com/24275308/206348001-3caeed3e-5492-41a5-99e3-b907120e408d.png)

